### PR TITLE
use safer implementations for to* functins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,13 +7,10 @@
     "output"
   ],
   "dependencies": {
-    "purescript-freet": "safareli/purescript-freet#patch-1",
+    "purescript-freet": "^4.1.0",
     "purescript-coroutines": "^5.0.0"
   },
-  "dev-dependencies": {
+  "devDependencies": {
     "purescript-aff": "^5.0.0"
-  },
-  "resolutions": {
-    "purescript-freet": "patch-1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,9 +7,13 @@
     "output"
   ],
   "dependencies": {
+    "purescript-freet": "safareli/purescript-freet#patch-1",
     "purescript-coroutines": "^5.0.0"
   },
   "dev-dependencies": {
     "purescript-aff": "^5.0.0"
+  },
+  "resolutions": {
+    "purescript-freet": "patch-1"
   }
 }

--- a/src/Control/Coroutine/Transducer.purs
+++ b/src/Control/Coroutine/Transducer.purs
@@ -58,7 +58,7 @@ fuse t1 t2 = freeT \_ -> go (Tuple t1 t2)
     proceed c (Right (Coproduct (Right s))) = pure (Right $ right $ map (fuse $ freeT $ \_ -> pure c) s)
     proceed (Right (Coproduct (Right (Tuple o next)))) (Right (Coproduct (Left f))) = resume (next `fuse` f (Just o))
     proceed (Right (Coproduct (Right (Tuple o next)))) (Left y) = resume (next `fuse` pure y)
-    proceed (Left x) (Right (Coproduct (Left f))) = resume (pure x `fuse` f Nothing)
+    proceed (Left z) (Right (Coproduct (Left f))) = resume (pure z `fuse` f Nothing)
     proceed (Left x) (Left y) = pure <<< Left $ (Tuple x y)
 
 infixr 2 fuse as =>=

--- a/src/Control/Coroutine/Transducer.purs
+++ b/src/Control/Coroutine/Transducer.purs
@@ -20,7 +20,7 @@ module Control.Coroutine.Transducer
 import Prelude
 
 import Control.Coroutine (Await(..), Co, CoTransform(..), CoTransformer, Consumer, Emit(..), Process, Producer, Transform(..), Transformer, loop)
-import Control.Monad.Free.Trans (freeT, interpret, resume)
+import Control.Monad.Free.Trans (freeT, interpret, liftFreeT, resume, substFreeT)
 import Control.Monad.Rec.Class (class MonadRec)
 import Control.Monad.Trans.Class (lift)
 import Control.Parallel (class Parallel, parallel, sequential)
@@ -29,8 +29,6 @@ import Data.Functor.Coproduct (Coproduct(..), left, right)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Traversable (traverse_)
 import Data.Tuple (Tuple(..))
-import Partial.Unsafe (unsafePartial)
-import Unsafe.Coerce (unsafeCoerce)
 
 
 type Transducer i o = Co (Coproduct ((->) (Maybe i)) (Tuple o))
@@ -113,15 +111,17 @@ fromProducer :: forall m o r. Monad m => Producer o m r -> Transducer Void o m r
 fromProducer = interpret (\(Emit o a) -> right $ Tuple o a)
 
 toProducer :: forall m o r. Monad m => Transducer Void o m r -> Producer o m r
-toProducer = interpret (unsafePartial $ case _ of
-  Coproduct (Right (Tuple o a)) -> Emit o a)
+toProducer = substFreeT case _ of
+  Coproduct (Left f) -> pure (f Nothing)
+  Coproduct (Right (Tuple o a)) -> liftFreeT $ Emit o a
 
 fromConsumer :: forall m i r. Monad m => Consumer (Maybe i) m r -> Transducer i Void m r
 fromConsumer = interpret (\(Await f) -> left f)
 
 toConsumer :: forall m i r. Monad m => Transducer i Void m r -> Consumer (Maybe i) m r
-toConsumer = interpret (unsafePartial $ case _ of
-  Coproduct (Left f) -> Await f)
+toConsumer = interpret case _ of
+  Coproduct (Left f) -> Await f
+  Coproduct (Right (Tuple void' _)) -> absurd void'
 
 fromTransformer :: forall i o m x. MonadRec m => Transformer i o m x -> Transducer i o m Unit
 fromTransformer t = do
@@ -147,5 +147,7 @@ fromCoTransformer t = do
       mi <- awaitT
       maybe (pure unit) (fromCoTransformer <<< f) mi
 
-toProcess :: forall m x. Functor m => Transducer Void Void m x -> Process m x
-toProcess = interpret (unsafeCoerce unit)
+toProcess :: forall m x. Monad m => Transducer Void Void m x -> Process m x
+toProcess = substFreeT case _ of
+  Coproduct (Left f) -> pure (f Nothing)
+  Coproduct (Right (Tuple void' _)) -> absurd void'


### PR DESCRIPTION
Without this change toProcess and toConsumer are *incorrect* as this will compile:

``` purs
x :: forall m. Monad m => Transducer Void Void m Unit
x = do
  res <- awaitT
  case res of
    Just void' -> absurd void'
    Nothing -> pure unit
```